### PR TITLE
Feat/provider tests

### DIFF
--- a/src/keeper.test.ts
+++ b/src/keeper.test.ts
@@ -29,8 +29,8 @@ describe("keeper", () => {
         if (arg.contract === "FuturesMarket") {
           return { abi: "__FuturesMarketContractAbi__" };
         }
-        if (arg.contract === "ExchangeRatesWithoutInvPricing") {
-          return { abi: "__ExchangeRatesWithoutInvPricingAbi__" };
+        if (arg.contract === "ExchangeRates") {
+          return { abi: "__ExchangeRatesAbi__" };
         }
       }),
     };
@@ -56,7 +56,7 @@ describe("keeper", () => {
     });
     expect(snx.getSource).toHaveBeenNthCalledWith(2, {
       network: args.network,
-      contract: "ExchangeRatesWithoutInvPricing",
+      contract: "ExchangeRates",
       useOvm: true,
     });
 
@@ -70,7 +70,7 @@ describe("keeper", () => {
     expect(deps.Contract).toHaveBeenNthCalledWith(
       2,
       "__EXCHANGE_RATES__",
-      "__ExchangeRatesWithoutInvPricingAbi__",
+      "__ExchangeRatesAbi__",
       "__PROVIDER__"
     );
     expect(baseAssetMock).toBeCalledTimes(1);

--- a/src/keeper.ts
+++ b/src/keeper.ts
@@ -120,9 +120,10 @@ class Keeper {
       contract: "FuturesMarket",
       useOvm: true,
     }).abi;
+
     const ExchangeRatesABI = deps.snx.getSource({
       network,
-      contract: "ExchangeRatesWithoutInvPricing",
+      contract: "ExchangeRates",
       useOvm: true,
     }).abi;
 

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -69,6 +69,7 @@ describe("provider", () => {
     test("ws works", async () => {
       jest.useFakeTimers();
       const providerMock = {
+        connection: { url: "test.com" },
         _websocket: {
           on: jest.fn().mockImplementation((event, cb) => {
             // Trigger open event directly
@@ -128,6 +129,7 @@ describe("provider", () => {
     test("ws terminates and exits if open socket doesn't respond within WS_PROVIDER_TIMEOUT", () => {
       jest.useFakeTimers();
       const providerMock = {
+        connection: { url: "test.com" },
         _websocket: {
           on: jest.fn().mockImplementation((event, cb) => {
             // Trigger open event directly
@@ -156,6 +158,7 @@ describe("provider", () => {
     });
     test("JSON RPC provider works", async () => {
       const providerMock = {
+        connection: { url: "test.com" },
         getBlock: jest.fn().mockResolvedValue("__BLOCK__"),
       } as any;
       const deps = {
@@ -183,6 +186,7 @@ describe("provider", () => {
 
     test("JSON RPC provider exits if open socket doesn't respond within WS_PROVIDER_TIMEOUT", () => {
       const providerMock = {
+        connection: { url: "test.com" },
         getBlock: jest.fn().mockImplementation(() => new Promise(() => {})), // simulate getBlock promise never resolves
       } as any;
       const deps = {

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -1,0 +1,68 @@
+import { getProvider } from "./provider";
+
+describe("provider", () => {
+  describe("getProvider", () => {
+    beforeEach(() => jest.clearAllMocks());
+    const deps = {
+      providers: {
+        JsonRpcProvider: jest.fn(),
+        WebSocketProvider: jest.fn(),
+      },
+    } as any;
+    test("https", () => {
+      const result = getProvider("https://infura.com", deps);
+
+      expect(deps.providers.JsonRpcProvider).toBeCalledTimes(1);
+      expect(deps.providers.JsonRpcProvider).toBeCalledWith({
+        timeout: 120000,
+        url: "https://infura.com",
+      });
+      expect(deps.providers.WebSocketProvider).not.toBeCalled();
+      expect(result).toEqual(deps.providers.JsonRpcProvider.mock.instances[0]);
+    });
+    test("http", () => {
+      const result = getProvider("http://infura.com", deps);
+
+      expect(deps.providers.JsonRpcProvider).toBeCalledTimes(1);
+      expect(deps.providers.JsonRpcProvider).toBeCalledWith({
+        timeout: 120000,
+        url: "http://infura.com",
+      });
+      expect(deps.providers.WebSocketProvider).not.toBeCalled();
+      expect(result).toEqual(deps.providers.JsonRpcProvider.mock.instances[0]);
+    });
+    test("wss", () => {
+      const result = getProvider("ws://infura.com", deps);
+
+      expect(deps.providers.WebSocketProvider).toBeCalledTimes(1);
+      expect(deps.providers.WebSocketProvider).toBeCalledWith({
+        timeout: 120000,
+        url: "ws://infura.com",
+        pollingInterval: 50,
+      });
+      expect(deps.providers.JsonRpcProvider).not.toBeCalled();
+      expect(result).toEqual(
+        deps.providers.WebSocketProvider.mock.instances[0]
+      );
+    });
+    test("ws", () => {
+      const result = getProvider("wss://infura.com", deps);
+
+      expect(deps.providers.WebSocketProvider).toBeCalledTimes(1);
+      expect(deps.providers.WebSocketProvider).toBeCalledWith({
+        timeout: 120000,
+        url: "wss://infura.com",
+        pollingInterval: 50,
+      });
+      expect(deps.providers.JsonRpcProvider).not.toBeCalled();
+      expect(result).toEqual(
+        deps.providers.WebSocketProvider.mock.instances[0]
+      );
+    });
+    test("throws when invalid url", () => {
+      expect(() => {
+        getProvider("bad url", deps);
+      }).toThrowError("Invalid URL");
+    });
+  });
+});

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -1,4 +1,4 @@
-import { getProvider } from "./provider";
+import { getProvider, monitorProvider } from "./provider";
 
 describe("provider", () => {
   describe("getProvider", () => {
@@ -63,6 +63,96 @@ describe("provider", () => {
       expect(() => {
         getProvider("bad url", deps);
       }).toThrowError("Invalid URL");
+    });
+  });
+  describe("monitorProvider", () => {
+    test("ws works", async () => {
+      jest.useFakeTimers();
+      const providerMock = {
+        _websocket: {
+          on: jest.fn().mockImplementation((event, cb) => {
+            // Trigger open event directly
+            if (event === "open") cb();
+            if (event === "pong") cb();
+          }),
+          terminate: jest.fn(),
+          ping: jest.fn(),
+        },
+      } as any;
+      const deps = {
+        WS_PROVIDER_TIMEOUT: 2 * 60 * 1000,
+        HEARTBEAT_INTERVAL: 3000,
+        ethNodeUptime: { set: jest.fn() },
+        ethNodeHeartbeatRTT: { observe: jest.fn() },
+      } as any;
+
+      const stopMonitoring = monitorProvider(providerMock, deps);
+
+      // Assert event listeners gets setup correctly
+      expect(providerMock._websocket.on).toBeCalledTimes(3);
+      expect(providerMock._websocket.on).toHaveBeenNthCalledWith(
+        1,
+        "open",
+        expect.any(Function)
+      );
+      expect(providerMock._websocket.on).toHaveBeenNthCalledWith(
+        2,
+        "pong",
+        expect.any(Function)
+      );
+      expect(providerMock._websocket.on).toHaveBeenNthCalledWith(
+        3,
+        "close",
+        expect.any(Function)
+      );
+      expect(providerMock._websocket.ping).not.toHaveBeenCalled();
+
+      // Assert ping gets called when heartbeat interval is triggered
+      jest.advanceTimersByTime(deps.HEARTBEAT_INTERVAL);
+      expect(providerMock._websocket.ping).toBeCalledTimes(1);
+
+      // Ensure the promises in the interval gets resolved
+      jest.useRealTimers();
+      await new Promise(process.nextTick);
+
+      // Assert that metrics gets called.
+      expect(deps.ethNodeUptime.set).toBeCalledTimes(1);
+      expect(deps.ethNodeUptime.set).toBeCalledWith(1);
+      expect(deps.ethNodeHeartbeatRTT.observe).toBeCalledTimes(1);
+      expect(deps.ethNodeHeartbeatRTT.observe).toBeCalledWith(
+        expect.any(Number)
+      );
+      // Stop monitoring to avoid jest worker process warning
+      stopMonitoring();
+    });
+    test("ws terminates and exits if open socket doesn't respond within WS_PROVIDER_TIMEOUT", () => {
+      jest.useFakeTimers();
+      const providerMock = {
+        _websocket: {
+          on: jest.fn().mockImplementation((event, cb) => {
+            // Trigger open event directly
+            if (event === "open") cb();
+            if (event === "pong") {
+            } // do not respond to pong event
+          }),
+          terminate: jest.fn(),
+          ping: jest.fn(),
+        },
+      } as any;
+      const deps = {
+        WS_PROVIDER_TIMEOUT: 2 * 60 * 1000,
+        HEARTBEAT_INTERVAL: 3000,
+        ethNodeUptime: { set: jest.fn() },
+        ethNodeHeartbeatRTT: { observe: jest.fn() },
+      } as any;
+      const processExitSpy = jest.spyOn(process, "exit").mockImplementation();
+      const stopMonitoring = monitorProvider(providerMock, deps);
+      jest.advanceTimersByTime(deps.WS_PROVIDER_TIMEOUT);
+
+      expect(processExitSpy).toBeCalledWith(1);
+      expect(providerMock._websocket.terminate).toBeCalled();
+      stopMonitoring();
+      jest.useRealTimers();
     });
   });
 });

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -150,8 +150,9 @@ export const monitorProvider = (
           logger.info("ping");
           stopwatch.start();
           await runNextTick(async () => {
-            provider.getBlock("latest");
+            await provider.getBlock("latest");
           });
+
           const ms = stopwatch.stop();
           logger.info(`pong rtt=${ms}ms`);
 
@@ -164,9 +165,9 @@ export const monitorProvider = (
         }
         clearTimeout(heartbeatTimeout);
 
-        await new Promise((res, rej) =>
-          setTimeout(res, deps.HEARTBEAT_INTERVAL)
-        );
+        await new Promise((res, rej) => {
+          heartbeatInterval = setTimeout(res, deps.HEARTBEAT_INTERVAL);
+        });
       }
     }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { providers } from "ethers";
 
 import * as metrics from "./metrics";
 import { createLogger } from "./logging";
@@ -41,128 +41,127 @@ class Stopwatch {
 const WS_PROVIDER_TIMEOUT = 2 * 60 * 1000;
 const HTTP_PROVIDER_TIMEOUT = WS_PROVIDER_TIMEOUT;
 
-export class Providers {
-  static create(providerUrl: string) {
-    const url = new URL(providerUrl);
+export const getProvider = (providerUrl: string, deps = { providers }) => {
+  const url = new URL(providerUrl);
 
-    if (url.protocol.match(/^(ws|wss):/)) {
-      // @ts-ignore TODO, it seems like we instantiate this incorrectly
-      return new ethers.providers.WebSocketProvider({
-        url: providerUrl,
-        pollingInterval: 50,
-        timeout: WS_PROVIDER_TIMEOUT,
-      });
-    }
-    if (url.protocol.match(/^(http|https):/)) {
-      return new ethers.providers.JsonRpcProvider({
-        url: providerUrl,
-        // pollingInterval: 50,  pollingInterval is not a valid option
-        timeout: HTTP_PROVIDER_TIMEOUT,
-      });
-      // provider = new ethers.providers.InfuraProvider({
-      //     url: "https://optimism-kovan.infura.io/v3/8b1cbf82d4004d63acd4aa9829bc6d15",
-      //     network: "optimism-kovan",
-      //     pollingInterval: 50,
-      //     timeout: 1000 * 60 // 1 minute
-      // });
-    }
-    throw new Error("Unknown provider protocol scheme - " + url.protocol);
+  if (url.protocol.match(/^(ws|wss):/)) {
+    // @ts-ignore TODO, it seems like we instantiate this incorrectly
+    return new deps.providers.WebSocketProvider({
+      url: providerUrl,
+      pollingInterval: 50,
+      timeout: WS_PROVIDER_TIMEOUT,
+    });
   }
-
-  // Setup the provider to exit the process if a connection is closed.
-  static monitor(
-    provider:
-      | ethers.providers.JsonRpcProvider
-      | ethers.providers.WebSocketProvider
-  ) {
-    const HEARTBEAT_INTERVAL = 10000;
-    let heartbeatTimeout: NodeJS.Timeout | undefined;
-    const stopwatch = new Stopwatch();
-
-    if ("_websocket" in provider) {
-      async function monitorWs(provider: ethers.providers.WebSocketProvider) {
-        while (true) {
-          // Listen for timeout.
-          heartbeatTimeout = setTimeout(() => {
-            logger.error("The heartbeat to the RPC provider timed out.");
-            heartbeatTimeout && clearTimeout(heartbeatTimeout);
-
-            // Use `WebSocket#terminate()`, which immediately destroys the connection,
-            // instead of `WebSocket#close()`, which waits for the close timer.
-            provider._websocket.terminate();
-            process.exit(1);
-          }, WS_PROVIDER_TIMEOUT);
-
-          // Heartbeat.
-          try {
-            logger.info("ping");
-            const pong = new Promise((res, rej) => {
-              provider._websocket.on("pong", res);
-            });
-
-            stopwatch.start();
-            await runNextTick(async () => provider._websocket.ping());
-            await pong;
-            const ms = stopwatch.stop();
-
-            logger.info(`pong rtt=${ms}ms`);
-            metrics.ethNodeUptime.set(1);
-            metrics.ethNodeHeartbeatRTT.observe(ms);
-          } catch (e) {
-            const errorMessage = getErrorMessage(e);
-            logger.error("Error while pinging provider: " + errorMessage);
-            process.exit(-1);
-          }
-          clearTimeout(heartbeatTimeout);
-
-          await new Promise((res, rej) => setTimeout(res, HEARTBEAT_INTERVAL));
-        }
-      }
-
-      provider._websocket.on("open", () => {
-        monitorWs(provider);
-      });
-
-      provider._websocket.on("close", () => {
-        logger.error("The websocket connection was closed");
-
-        heartbeatTimeout && clearTimeout(heartbeatTimeout);
-        process.exit(1);
-      });
-    } else {
-      async function monitor() {
-        while (true) {
-          // Listen for timeout.
-          heartbeatTimeout = setTimeout(() => {
-            logger.error("The heartbeat to the RPC provider timed out.");
-            heartbeatTimeout && clearTimeout(heartbeatTimeout);
-            process.exit(1);
-          }, HTTP_PROVIDER_TIMEOUT);
-
-          // Heartbeat.
-          try {
-            logger.info("ping");
-            stopwatch.start();
-            await runNextTick(async () => {
-              provider.getBlock("latest");
-            });
-            const ms = stopwatch.stop();
-            logger.info(`pong rtt=${ms}ms`);
-
-            metrics.ethNodeUptime.set(1);
-            metrics.ethNodeHeartbeatRTT.observe(ms);
-          } catch (e) {
-            const errorMessage = getErrorMessage(e);
-            logger.error("Error while pinging provider: " + errorMessage);
-            process.exit(-1);
-          }
-          clearTimeout(heartbeatTimeout);
-
-          await new Promise((res, rej) => setTimeout(res, HEARTBEAT_INTERVAL));
-        }
-      }
-
-      monitor();
-    }
+  if (url.protocol.match(/^(http|https):/)) {
+    return new deps.providers.JsonRpcProvider({
+      url: providerUrl,
+      // pollingInterval: 50,  pollingInterval is not a valid option
+      timeout: HTTP_PROVIDER_TIMEOUT,
+    });
+    // provider = new ethers.providers.InfuraProvider({
+    //     url: "https://optimism-kovan.infura.io/v3/8b1cbf82d4004d63acd4aa9829bc6d15",
+    //     network: "optimism-kovan",
+    //     pollingInterval: 50,
+    //     timeout: 1000 * 60 // 1 minute
+    // });
   }
-}
+  throw new Error("Unknown provider protocol scheme - " + url.protocol);
+};
+
+export const monitorProvider = (
+  provider: providers.JsonRpcProvider | providers.WebSocketProvider,
+  deps = { whileLoopCondition: true, HEARTBEAT_INTERVAL: 10000 }
+) => {
+  let heartbeatTimeout: NodeJS.Timeout | undefined;
+  const stopwatch = new Stopwatch();
+
+  if ("_websocket" in provider) {
+    async function monitorWsProvider(provider: providers.WebSocketProvider) {
+      while (true) {
+        // Listen for timeout.
+        heartbeatTimeout = setTimeout(() => {
+          logger.error("The heartbeat to the RPC provider timed out.");
+          heartbeatTimeout && clearTimeout(heartbeatTimeout);
+
+          // Use `WebSocket#terminate()`, which immediately destroys the connection,
+          // instead of `WebSocket#close()`, which waits for the close timer.
+          provider._websocket.terminate();
+          process.exit(1);
+        }, WS_PROVIDER_TIMEOUT);
+
+        // Heartbeat.
+        try {
+          logger.info("ping");
+          const pong = new Promise((res, rej) => {
+            provider._websocket.on("pong", res);
+          });
+
+          stopwatch.start();
+          await runNextTick(async () => provider._websocket.ping());
+          await pong;
+          const ms = stopwatch.stop();
+
+          logger.info(`pong rtt=${ms}ms`);
+          metrics.ethNodeUptime.set(1);
+          metrics.ethNodeHeartbeatRTT.observe(ms);
+        } catch (e) {
+          const errorMessage = getErrorMessage(e);
+          logger.error("Error while pinging provider: " + errorMessage);
+          process.exit(-1);
+        }
+        clearTimeout(heartbeatTimeout);
+
+        await new Promise((res, rej) =>
+          setTimeout(res, deps.HEARTBEAT_INTERVAL)
+        );
+      }
+    }
+
+    provider._websocket.on("open", () => {
+      monitorWsProvider(provider);
+    });
+
+    provider._websocket.on("close", () => {
+      logger.error("The websocket connection was closed");
+
+      heartbeatTimeout && clearTimeout(heartbeatTimeout);
+      process.exit(1);
+    });
+  } else {
+    async function monitorJsonProvider() {
+      while (true) {
+        // Listen for timeout.
+        heartbeatTimeout = setTimeout(() => {
+          logger.error("The heartbeat to the RPC provider timed out.");
+          heartbeatTimeout && clearTimeout(heartbeatTimeout);
+          process.exit(1);
+        }, HTTP_PROVIDER_TIMEOUT);
+
+        // Heartbeat.
+        try {
+          logger.info("ping");
+          stopwatch.start();
+          await runNextTick(async () => {
+            provider.getBlock("latest");
+          });
+          const ms = stopwatch.stop();
+          logger.info(`pong rtt=${ms}ms`);
+
+          metrics.ethNodeUptime.set(1);
+          metrics.ethNodeHeartbeatRTT.observe(ms);
+        } catch (e) {
+          const errorMessage = getErrorMessage(e);
+          logger.error("Error while pinging provider: " + errorMessage);
+          process.exit(-1);
+        }
+        clearTimeout(heartbeatTimeout);
+
+        await new Promise((res, rej) =>
+          setTimeout(res, deps.HEARTBEAT_INTERVAL)
+        );
+      }
+    }
+
+    monitorJsonProvider();
+  }
+};

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -38,7 +38,10 @@ class Stopwatch {
   }
 }
 
-export const getProvider = (providerUrl: string, deps = { providers }) => {
+export const getProvider = (
+  providerUrl: string,
+  deps = { providers }
+): providers.JsonRpcProvider | providers.WebSocketProvider => {
   const url = new URL(providerUrl);
 
   if (url.protocol.match(/^(ws|wss):/)) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -101,7 +101,7 @@ export const monitorProvider = (
 
         // Heartbeat.
         try {
-          logger.info("ping");
+          logger.info(`ping (${provider.connection.url})`);
           const pong = new Promise((res, rej) => {
             provider._websocket.on("pong", res);
           });
@@ -150,13 +150,14 @@ export const monitorProvider = (
 
         // Heartbeat.
         try {
-          logger.info("ping");
+          logger.info(`ping (${provider.connection.url})`);
           stopwatch.start();
           await runNextTick(async () => {
             await provider.getBlock("latest");
           });
 
           const ms = stopwatch.stop();
+
           logger.info(`pong rtt=${ms}ms`);
 
           deps.ethNodeUptime.set(1);

--- a/src/run/run.test.ts
+++ b/src/run/run.test.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from "@ethersproject/bignumber";
 import { DEFAULTS, run } from "./index";
 
 describe("run", () => {
@@ -18,7 +17,7 @@ describe("run", () => {
     ).rejects.toEqual(Error("No futures market for currencyKey: sDOGE"));
   });
   test("happy path", async () => {
-    const providerCreateMock = jest.fn().mockReturnValue("__PROVIDER__");
+    const getProviderMock = jest.fn().mockReturnValue("__PROVIDER__");
     const providerMonitorMock = jest.fn();
     const NonceManagerMock = jest.fn();
     const NonceManagerConnectMock = jest.fn().mockReturnValue("__SIGNER__");
@@ -31,10 +30,8 @@ describe("run", () => {
 
     const deps = {
       ETH_HDWALLET_MNEMONIC: "fake words",
-      Providers: {
-        create: providerCreateMock,
-        monitor: providerMonitorMock,
-      },
+      getProvider: getProviderMock,
+      monitorProvider: providerMonitorMock,
       NonceManager: NonceManagerMock.mockReturnValue({
         connect: NonceManagerConnectMock,
       }),
@@ -54,8 +51,8 @@ describe("run", () => {
 
     expect(metricsRunServerMock).toBeCalledTimes(1);
 
-    expect(providerCreateMock).toBeCalledTimes(1);
-    expect(providerCreateMock).toBeCalledWith(DEFAULTS.providerUrl);
+    expect(getProviderMock).toBeCalledTimes(1);
+    expect(getProviderMock).toBeCalledWith(DEFAULTS.providerUrl);
     expect(providerMonitorMock).toBeCalledTimes(1);
     expect(providerMonitorMock).toBeCalledWith("__PROVIDER__");
 

--- a/src/run/run.ts
+++ b/src/run/run.ts
@@ -5,7 +5,7 @@ import snx from "synthetix";
 import Keeper from "../keeper";
 import SignerPool from "../signer-pool";
 import { runServer as runMetricServer } from "../metrics";
-import { Providers } from "../provider";
+import { getProvider, monitorProvider } from "../provider";
 import { CommanderStatic } from "commander";
 import createWallets from "./createWallets";
 import logAndStartTrackingBalances from "./logAndStartTrackingBalances";
@@ -34,7 +34,8 @@ export async function run(
   } = {},
   deps = {
     ETH_HDWALLET_MNEMONIC: process.env.ETH_HDWALLET_MNEMONIC,
-    Providers,
+    getProvider,
+    monitorProvider,
     NonceManager,
     SignerPool,
     Keeper,
@@ -65,8 +66,8 @@ export async function run(
     fromBlockRaw === "latest" ? fromBlockRaw : parseInt(fromBlockRaw);
 
   // Setup.
-  const provider = deps.Providers.create(providerUrl);
-  deps.Providers.monitor(provider);
+  const provider = deps.getProvider(providerUrl);
+  deps.monitorProvider(provider);
   console.log(gray(`Connected to Ethereum node at ${providerUrl}`));
 
   let unWrappedSigners = deps.createWallets({


### PR DESCRIPTION
I've tested that the Provider module still works with my refactor.
```
//test.ts
const run = async () => {
  const rpcUrl = "https://kovan.optimism.io";
  const provider = getProvider(rpcUrl);
  monitorProvider(provider, {
    WS_PROVIDER_TIMEOUT,
    HTTP_PROVIDER_TIMEOUT,
    HEARTBEAT_INTERVAL,
    ethNodeUptime: {
      set: (arg: any) => console.log("ethNodeUptime.set called with: ", arg),
    } as any,
    ethNodeHeartbeatRTT: {
      observe: (arg: any) =>
        console.log("ethNodeHeartbeatRTT.observe called with: ", arg),
    } as any,
  });
};
run();
```
Tested JSON RPC provider on Optimism Kovan and Optimism. Both with infura and the RPC from optimism
Tested WebSocket provider on Optimism Kovan and Optimism, infura doesn't seem to have support for websocket + optimism so only tested with  RPC from optimism