### PR TITLE
Explicit events

### DIFF
--- a/futures-interact-cli/index.ts
+++ b/futures-interact-cli/index.ts
@@ -137,8 +137,7 @@ const checkPos = async (arg: CheckPosArg) => {
     wallet.address
   );
   const [liqPrice] = await futuresMarketContract.liquidationPrice(
-    wallet.address,
-    false
+    wallet.address
   );
   const [
     _id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "futures-keepers",
 			"version": "1.0.0",
+			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ethersproject/abstract-provider": "5.5.1",
@@ -33,7 +34,7 @@
 				"prettier": "~1.19.1",
 				"pretty-error": "^3.0.4",
 				"prom-client": "^14.0.0",
-				"synthetix": "github:Synthetixio/synthetix#92effdb9f9bb6f29703acf465c114e9c94f2da68",
+				"synthetix": "github:Synthetixio/synthetix#8ab725f1256a6192444282446642fdb383c9e716",
 				"typescript": "4.5.2",
 				"winston": "^3.3.3"
 			},
@@ -16615,9 +16616,9 @@
 			"dev": true
 		},
 		"node_modules/synthetix": {
-			"version": "2.56.1",
-			"resolved": "git+ssh://git@github.com/Synthetixio/synthetix.git#92effdb9f9bb6f29703acf465c114e9c94f2da68",
-			"integrity": "sha512-6XgiVMzZHdGSo0Y166EZugbSGnrraACfMbj2jP4JsjpvvVp7GhHr4MVdz3tPhkoTRmpcvyaV9zVgahpr9oWAAQ==",
+			"version": "2.63.0",
+			"resolved": "git+ssh://git@github.com/Synthetixio/synthetix.git#8ab725f1256a6192444282446642fdb383c9e716",
+			"integrity": "sha512-6T4uK8w6THp+F09Rg1lRR9EARAa++JbSCpuvldnKTVgvzQN/A/ScDIb7pXGcBOvJSyIXD+J50ruPa7bTY08a9g==",
 			"license": "MIT",
 			"dependencies": {
 				"abi-decoder": "2.3.0",
@@ -31128,9 +31129,9 @@
 			"dev": true
 		},
 		"synthetix": {
-			"version": "git+ssh://git@github.com/Synthetixio/synthetix.git#92effdb9f9bb6f29703acf465c114e9c94f2da68",
-			"integrity": "sha512-6XgiVMzZHdGSo0Y166EZugbSGnrraACfMbj2jP4JsjpvvVp7GhHr4MVdz3tPhkoTRmpcvyaV9zVgahpr9oWAAQ==",
-			"from": "synthetix@github:Synthetixio/synthetix#92effdb9f9bb6f29703acf465c114e9c94f2da68",
+			"version": "git+ssh://git@github.com/Synthetixio/synthetix.git#8ab725f1256a6192444282446642fdb383c9e716",
+			"integrity": "sha512-6T4uK8w6THp+F09Rg1lRR9EARAa++JbSCpuvldnKTVgvzQN/A/ScDIb7pXGcBOvJSyIXD+J50ruPa7bTY08a9g==",
+			"from": "synthetix@github:Synthetixio/synthetix#8ab725f1256a6192444282446642fdb383c9e716",
 			"requires": {
 				"abi-decoder": "2.3.0",
 				"commander": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
 		"build": "tsc",
 		"lint": "eslint \"src/**/*.js\" \"tools/**/*.js\" *.js",
 		"lint:fix": "eslint --fix \"src/**/*.js\" \"tools/**/*.js\" *.js",
-		"start-eth-node": "hardhat node --fork https://optimism-kovan.infura.io/v3/67f6e82867b047de8e9bdeb68c5f93a5",
 		"postinstall": "patch-package"
 	},
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"prettier": "~1.19.1",
 		"pretty-error": "^3.0.4",
 		"prom-client": "^14.0.0",
-		"synthetix": "github:Synthetixio/synthetix#92effdb9f9bb6f29703acf465c114e9c94f2da68",
+		"synthetix": "github:Synthetixio/synthetix#8ab725f1256a6192444282446642fdb383c9e716",
 		"typescript": "4.5.2",
 		"winston": "^3.3.3"
 	},

--- a/src/keeper.test.ts
+++ b/src/keeper.test.ts
@@ -1,28 +1,28 @@
 import { BigNumber } from "@ethersproject/bignumber";
 import { wei } from "@synthetixio/wei";
 import Keeper from "./keeper";
-import * as metrics from "./metrics";
+
 const getMockPositions = () => ({
   ___ACCOUNT1__: {
     id: "1",
     event: "__OLD_EVENT__",
     account: "___ACCOUNT1__",
     size: 10,
-    marginRatio: 1,
+    leverage: 1,
   },
   ___ACCOUNT2__: {
     id: "1",
     event: "__OLD_EVENT__",
     account: "___ACCOUNT2__",
     size: 10,
-    marginRatio: 1,
+    leverage: 1,
   },
   ___ACCOUNT3__: {
     id: "1",
     event: "__OLD_EVENT__",
     account: "___ACCOUNT3__",
     size: 10,
-    marginRatio: 1,
+    leverage: 1,
   },
 });
 describe("keeper", () => {
@@ -142,7 +142,7 @@ describe("keeper", () => {
       event: "PositionModified",
       id: "1",
       size: 1,
-      marginRatio: 2,
+      leverage: 2,
     });
     /**
      * PositionModified to 0
@@ -173,7 +173,7 @@ describe("keeper", () => {
         event: "__OLD_EVENT__",
         account: "___ACCOUNT3__",
         size: 10,
-        marginRatio: 1,
+        leverage: 1,
       },
     });
   });
@@ -225,7 +225,16 @@ describe("keeper", () => {
       provider: jest.fn(),
     } as any;
     const keeper = new Keeper(arg);
-    const mockPosition = getMockPositions();
+    const mockPosition = {
+      ...getMockPositions(),
+      ___ACCOUNT4__: {
+        id: "4",
+        event: "__OLD_EVENT__",
+        account: "___ACCOUNT4__",
+        size: 10,
+        leverage: 2,
+      },
+    };
     keeper.positions = mockPosition;
     const runKeeperTaskSpy = jest.spyOn(keeper, "runKeeperTask");
     const liquidateOrderSpy = jest
@@ -244,40 +253,51 @@ describe("keeper", () => {
     expect(futuresOpenPositionsSetMock).toBeCalledTimes(1);
     expect(futuresOpenPositionsSetMock).toHaveBeenCalledWith(
       { market: "sUSD" },
-      3
+      4
     );
-    expect(runKeeperTaskSpy).toBeCalledTimes(3);
+    expect(runKeeperTaskSpy).toBeCalledTimes(4);
     expect(runKeeperTaskSpy).toHaveBeenNthCalledWith(
       1,
-      mockPosition["___ACCOUNT1__"].id,
+      mockPosition["___ACCOUNT4__"].id,
       "liquidation",
       expect.any(Function)
     );
     expect(runKeeperTaskSpy).toHaveBeenNthCalledWith(
       2,
-      mockPosition["___ACCOUNT2__"].id,
+      mockPosition["___ACCOUNT1__"].id,
       "liquidation",
       expect.any(Function)
     );
     expect(runKeeperTaskSpy).toHaveBeenNthCalledWith(
       3,
+      mockPosition["___ACCOUNT2__"].id,
+      "liquidation",
+      expect.any(Function)
+    );
+    expect(runKeeperTaskSpy).toHaveBeenNthCalledWith(
+      4,
       mockPosition["___ACCOUNT3__"].id,
       "liquidation",
       expect.any(Function)
     );
-    expect(liquidateOrderSpy).toBeCalledTimes(3);
+    expect(liquidateOrderSpy).toBeCalledTimes(4);
     expect(liquidateOrderSpy).toHaveBeenNthCalledWith(
       1,
+      mockPosition["___ACCOUNT4__"].id,
+      "___ACCOUNT4__"
+    );
+    expect(liquidateOrderSpy).toHaveBeenNthCalledWith(
+      2,
       mockPosition["___ACCOUNT1__"].id,
       "___ACCOUNT1__"
     );
     expect(liquidateOrderSpy).toHaveBeenNthCalledWith(
-      2,
+      3,
       mockPosition["___ACCOUNT2__"].id,
       "___ACCOUNT2__"
     );
     expect(liquidateOrderSpy).toHaveBeenNthCalledWith(
-      3,
+      4,
       mockPosition["___ACCOUNT3__"].id,
       "___ACCOUNT3__"
     );

--- a/src/keeper.test.ts
+++ b/src/keeper.test.ts
@@ -39,7 +39,7 @@ describe("keeper", () => {
     const Contract = jest.fn().mockReturnValue({ baseAsset: baseAssetMock });
 
     const args = {
-      proxyFuturesMarket: "__FUTURES_MARKET__",
+      futuresMarketAddress: "__FUTURES_MARKET__",
       signerPool: "__SIGNER_POOL__",
       provider: "__PROVIDER__",
       network: "kovan",

--- a/src/keeper.ts
+++ b/src/keeper.ts
@@ -243,7 +243,8 @@ class Keeper {
           account,
           size,
         };
-      } else if (event === "PositionLiquidated" && args) {
+        return;
+      }
         const { account, liquidator } = args;
         this.logger.log(
           "info",
@@ -252,20 +253,12 @@ class Keeper {
         );
 
         delete this.positions[account];
-      } else if (event === "FundingRecomputed") {
-        // // Recompute liquidation price of all positions.
-        // await Object.values(this.positions).map(position => {
-        //   const includeFunding = true
-        //   const { price: liqPrice, invalid } = await this.futuresMarket.liquidationPrice(position.account, includeFunding)
-        //   if (invalid) return
-        //   this.positions[position.account].liqPrice = liqPrice
-        // })
-      } else if (!event || event.match(/OrderSubmitted/)) {
-      } else {
-        this.logger.log("info", `No handler for event ${event}`, {
-          component: "Indexer",
-        });
+        return;
       }
+
+      this.logger.info(`No handler for event ${event}`, {
+        component: "Indexer",
+      });
     });
   }
 

--- a/src/keeper.ts
+++ b/src/keeper.ts
@@ -99,12 +99,12 @@ class Keeper {
 
   static async create(
     {
-      proxyFuturesMarket: proxyFuturesMarketAddress,
+      futuresMarketAddress,
       signerPool,
       provider,
       network,
     }: {
-      proxyFuturesMarket: string;
+      futuresMarketAddress: string;
       signerPool: SignerPool;
       network: string;
       provider:
@@ -122,7 +122,7 @@ class Keeper {
 
     // Contracts.
     const futuresMarket = new deps.Contract(
-      proxyFuturesMarketAddress,
+      futuresMarketAddress,
       FuturesMarketABI,
       provider
     );

--- a/src/keeper.ts
+++ b/src/keeper.ts
@@ -32,7 +32,7 @@ class Keeper {
       event: string;
       account: string;
       size: number;
-      marginRatio: number;
+      leverage: number;
     };
   };
   activeKeeperTasks: { [id: string]: boolean | undefined };
@@ -225,13 +225,24 @@ class Keeper {
           delete this.positions[account];
           return;
         }
+        //   PositionModified(
+        //     uint indexed id,
+        //     address indexed account,
+        //     uint margin,
+        //     int size,
+        //     int tradeSize,
+        //     uint lastPrice,
+        //     uint fundingIndex,
+        //     uint fee
+        // )
+        // This is what's avaiable, ideally we should calculate the liq price based on margin and size maybe?
 
         this.positions[account] = {
           id,
           event,
           account,
           size: wei(size).toNumber(),
-          marginRatio: wei(size)
+          leverage: wei(size)
             .mul(lastPrice)
             .div(margin)
             .toNumber(),
@@ -269,7 +280,7 @@ class Keeper {
     // Get current liquidation price for each position (including funding).
     const positions = orderBy(
       Object.values(this.positions),
-      ["marginRatio"],
+      ["leverage"],
       "desc"
     );
     for (const batch of chunk(positions, deps.BATCH_SIZE)) {

--- a/src/keeper.ts
+++ b/src/keeper.ts
@@ -207,22 +207,11 @@ class Keeper {
       blockNumber,
       blockNumber
     );
-    const exchangeRateEvents = await this.exchangeRates.queryFilter(
-      "*" as any,
-      blockNumber,
-      blockNumber
-    );
+    
 
     this.logger.log("debug", `\nProcessing block: ${blockNumber}`, {
       component: "Indexer",
     });
-    exchangeRateEvents
-      .filter(
-        ({ event, args }) => event === "RatesUpdated" || event === "RateDeleted"
-      )
-      .forEach(({ event }) => {
-        this.logger.log("debug", `ExchangeRates ${event}`);
-      });
 
     this.logger.log("debug", `${events.length} events to process`, {
       component: "Indexer",

--- a/src/keeper.ts
+++ b/src/keeper.ts
@@ -25,7 +25,6 @@ const EventsOfInterest = {
 class Keeper {
   baseAsset: string;
   futuresMarket: Contract;
-  exchangeRates: Contract;
   logger: Logger;
   positions: {
     [account: string]: {
@@ -46,13 +45,11 @@ class Keeper {
 
   constructor({
     futuresMarket,
-    exchangeRates,
     baseAsset,
     signerPool,
     provider,
   }: {
     futuresMarket: ethers.Contract;
-    exchangeRates: ethers.Contract;
     baseAsset: string;
     signerPool: SignerPool;
     provider:
@@ -63,7 +60,6 @@ class Keeper {
 
     // Contracts.
     this.futuresMarket = futuresMarket;
-    this.exchangeRates = exchangeRates;
 
     this.logger = winston.createLogger({
       level: "info",
@@ -104,13 +100,11 @@ class Keeper {
   static async create(
     {
       proxyFuturesMarket: proxyFuturesMarketAddress,
-      exchangeRates: exchangeRatesAddress,
       signerPool,
       provider,
       network,
     }: {
       proxyFuturesMarket: string;
-      exchangeRates: string;
       signerPool: SignerPool;
       network: string;
       provider:
@@ -126,22 +120,10 @@ class Keeper {
       useOvm: true,
     }).abi;
 
-    const ExchangeRatesABI = deps.snx.getSource({
-      network,
-      contract: "ExchangeRates",
-      useOvm: true,
-    }).abi;
-
     // Contracts.
     const futuresMarket = new deps.Contract(
       proxyFuturesMarketAddress,
       FuturesMarketABI,
-      provider
-    );
-
-    const exchangeRates = new deps.Contract(
-      exchangeRatesAddress,
-      ExchangeRatesABI,
       provider
     );
 
@@ -150,7 +132,6 @@ class Keeper {
 
     return new Keeper({
       futuresMarket,
-      exchangeRates,
       baseAsset,
       signerPool,
       provider,

--- a/src/run/run.test.ts
+++ b/src/run/run.test.ts
@@ -82,13 +82,14 @@ describe("run", () => {
 
     expect(KeeperMockCreate).toBeCalledTimes(3);
     expect(KeeperMockCreate).toBeCalledWith({
-      exchangeRates: expect.any(String),
       network: "kovan-ovm-futures",
       provider: "__PROVIDER__",
-      proxyFuturesMarket: expect.any(String),
+      futuresMarketAddress: expect.any(String),
       signerPool: "__SIGNER_POOL__",
     });
     expect(KeeperMockRun).toBeCalledTimes(3);
-    expect(KeeperMockRun).toBeCalledWith({ fromBlock: DEFAULTS.fromBlock });
+    expect(KeeperMockRun).toBeCalledWith({
+      fromBlock: Number(DEFAULTS.fromBlock),
+    });
   });
 });

--- a/src/run/run.ts
+++ b/src/run/run.ts
@@ -99,16 +99,10 @@ export async function run(
       useOvm: true,
     })
   );
-  const exchangeRates = snx.getTarget({
-    contract: "ExchangeRates",
-    network,
-    useOvm: true,
-  });
   for (const marketContract of marketContracts) {
     const keeper = await deps.Keeper.create({
       network,
       proxyFuturesMarket: marketContract.address,
-      exchangeRates: exchangeRates.address,
       signerPool,
       provider,
     });

--- a/src/run/run.ts
+++ b/src/run/run.ts
@@ -94,7 +94,7 @@ export async function run(
   // Load contracts.
   const marketContracts = marketsArray.map(market =>
     snx.getTarget({
-      contract: `ProxyFuturesMarket${market.slice(1)}`,
+      contract: `FuturesMarket${market.slice(1)}`,
       network,
       useOvm: true,
     })

--- a/src/run/run.ts
+++ b/src/run/run.ts
@@ -102,7 +102,7 @@ export async function run(
   for (const marketContract of marketContracts) {
     const keeper = await deps.Keeper.create({
       network,
-      proxyFuturesMarket: marketContract.address,
+      futuresMarketAddress: marketContract.address,
       signerPool,
       provider,
     });


### PR DESCRIPTION
Instead of fetching all events with *, we know explicityly fetch the events we care about. ATM that is `PositionModified` and `PositionLiquidated`
Also a little bit of clean up