### PR TITLE
Proper prometheus backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 ETH_HDWALLET_MNEMONIC="test test test test test test test test test test test junk"
 PROVIDER_URL="https://optimism-kovan.infura.io/v3/<infura key>"
 NETWORK=mainnet-ovm
+METRIC_SERVER_PORT=8084
 
 
 # wallets used for futures-interact-cli. Only needed when testing locally.

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
-# required keeper wallet and provider url 
+# required keeper wallet and provider url
 ETH_HDWALLET_MNEMONIC="test test test test test test test test test test test junk"
-PROVIDER_URL=https://optimism-kovan.infura.io/v3/<infura key>
+PROVIDER_URL="https://optimism-kovan.infura.io/v3/<infura key>"
 NETWORK=mainnet-ovm
+
 
 # wallets used for futures-interact-cli. Only needed when testing locally.
 INTERACT_WALLET_PRIVATE_KEY=

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Any variables specified in `.env` at the project root will be loaded using [dote
   **Optional variables**
 - **`NETWORK`**: The default network to be used, if not specified from CLI.
 - **`FROM_BLOCK`**: The default block number to index from, if not specified from CLI.
+- **`METRIC_SERVER_PORT`**: The port to run the metric server, default 8084
 
 **Optional variables used for testing on a local fork (see Futures interact CLI section):**
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,18 @@
+#!/bin/sh
+set -ex
+
+
+if [ -z $1 ] ; then
+    echo "PATH_TO_PRIVATE_KEY required!" && exit 1;
+fi
+
+if [ -z $2 ] ; then
+    echo "USER:IP parameter required!" && exit 1;
+fi
+if [ -z $3 ] ; then
+    echo "SERVER_PATH parameter required!" && exit 1;
+fi
+
 PATH_TO_PRIVATE_KEY=$1
 USER_AT_IP=$2
 SERVER_PATH=$3
@@ -23,7 +38,7 @@ confirm || exit 0
 
 ssh -i "$PATH_TO_PRIVATE_KEY" "$USER_AT_IP" mkdir -p "$SERVER_PATH"
 echo "Uploading files"
-rsync --exclude 'node_modules' --exclude 'build' --exclude 'coverage' --exclude 'cache' -e "ssh -i $1" -Pav "$PWD" "$USER_AT_IP":"$SERVER_PATH"
+rsync --exclude 'node_modules' --exclude 'build' --exclude 'coverage' --exclude 'cache' -e "ssh -i $PATH_TO_PRIVATE_KEY" -Pav "$PWD" "$USER_AT_IP":"$SERVER_PATH"
 
 echo "Installing deps, transpiling typescript and starting keeper"
 ssh -i "$PATH_TO_PRIVATE_KEY" "$USER_AT_IP" "cd $LOCAL_FOLDER_NAME;npm i;npm run build;npm run start"

--- a/prometheus/.env.example
+++ b/prometheus/.env.example
@@ -5,3 +5,5 @@ PROM_HTTP_PASSWORD=
 PROM_ENDPOINT_TO_SCRAPE=host.docker.internal:8084
 # The up metric cant use labels, so name the job based on the eth network used
 PROM_JOB_NAME=keeper-kovan-ovm
+# Port promethues is exposed to
+PROM_PORT=9090

--- a/prometheus/.env.example
+++ b/prometheus/.env.example
@@ -1,7 +1,5 @@
-# If using grafana you can create a prometheus dashboard and the values will be created for you
-PROM_REMOTE_WRITE_HOST=
-PROM_REMOTE_WRITE_USERNAME=
-PROM_REMOTE_WRITE_PASSWORD=
+# Should be encrypted with bcrypt (htpasswd -nBC 10 "" | tr -d ':\n')
+PROM_HTTP_PASSWORD=
 # We start the metric server on port 8084, since we run this in a docker container
 # we use host.docker.internal instead of localhost
 PROM_ENDPOINT_TO_SCRAPE=host.docker.internal:8084

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -1,11 +1,10 @@
 # prometheus
 
-A dockerised Prometheus setup designed to scrape and upload keeper metrics (uptime, liquidated positions) to a remote Prometheus backend.
+A dockerised Prometheus setup designed to scrape and upload keeper metrics (uptime, liquidated positions) to a Prometheus backend. You can connect an Grafana instance to this prometheus backend.
 
 1.  Prometheus is started on `localhost:9090`.
 2.  Keeper is started, and exposes a scrapable metrics endpoint at `http://localhost:8084`.
 3.  Prometheus scrapes the keeper metrics endpoint periodically (currently every 1s).
-4.  Using the remote write feature, Prometheus writes these metrics to a remote Prometheus backend - the recommended way is using a Grafana cloud instance, with Prometheus plugin installed.
 
 Since Prometheus configurations don't support environment variables, [confd](https://github.com/kelseyhightower/confd) is used to generate config from a template file.
 
@@ -16,13 +15,17 @@ The setup can be run with Docker Compose and configured using environment variab
 1.  `cp .env.example .env`
 2.  Configure the remote Prometheus backend. If using Grafana you can create a prometheus dashboard and the values will be created for you.
 
-    - `PROM_REMOTE_WRITE_HOST`
-    - `PROM_REMOTE_WRITE_USERNAME`
-    - `PROM_REMOTE_WRITE_PASSWORD`
-
-      The endpoint to scrape from. We start the metric server on port 8084, but since we run this in a docker container we use `host.docker.internal:8084` instead of `localhost:8084`
+    The endpoint to scrape from. We start the metric server on port 8084, but since we run this in a docker container we use `host.docker.internal:8084` instead of `localhost:8084`
 
     - `PROM_ENDPOINT_TO_SCRAPE`
+
+      Some of the metrics cant access label so to be able do differentiate kovan-ovm from mainnet-ovm we can provide a job name
+
+    - `PROM_JOB_NAME`
+
+      The setup configures prometheus to have basic http auth. This is the password to use. Prometheus expect the password to be encrypted with bcrypt, you can to encrypt with: `htpasswd -nBC 10 "" | tr -d ':\n'`
+
+    - `PROM_HTTP_PASSWORD`
 
 3.  Run the Docker container.
 

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -27,6 +27,10 @@ The setup can be run with Docker Compose and configured using environment variab
 
     - `PROM_HTTP_PASSWORD`
 
+      Exposed port
+
+    - `PROM_PORT`
+
 3.  Run the Docker container.
 
     ```sh

--- a/prometheus/confd/conf.d/prometheus-web.toml
+++ b/prometheus/confd/conf.d/prometheus-web.toml
@@ -1,0 +1,3 @@
+[template]
+src = "prometheus-web.yml"
+dest = "/etc/prometheus/confd-prometheus-web.yml"

--- a/prometheus/confd/templates/prometheus-web.yml
+++ b/prometheus/confd/templates/prometheus-web.yml
@@ -1,0 +1,2 @@
+basic_auth_users:
+  grafana: {{ getenv "PROM_HTTP_PASSWORD" }} 

--- a/prometheus/confd/templates/prometheus.yml
+++ b/prometheus/confd/templates/prometheus.yml
@@ -7,13 +7,4 @@ scrape_configs:
     static_configs:
       - targets: ['{{ getenv "PROM_ENDPOINT_TO_SCRAPE" }}']
 
-remote_write:
-- url: {{ getenv "PROM_REMOTE_WRITE_HOST" }}
-  basic_auth:
-    username: {{ getenv "PROM_REMOTE_WRITE_USERNAME" }}
-    password: {{ getenv "PROM_REMOTE_WRITE_PASSWORD" }}
-  metadata_config:
-    send: true
-    send_interval: 10s
-    max_samples_per_send: 500
 

--- a/prometheus/docker-compose.yml
+++ b/prometheus/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   prometheus:
     build: .
     ports:
-     - 9090:9090
+     - ${PROM_PORT}:9090
     environment:
      - PROM_ENDPOINT_TO_SCRAPE
      - PROM_JOB_NAME

--- a/prometheus/docker-compose.yml
+++ b/prometheus/docker-compose.yml
@@ -3,15 +3,11 @@ version: '3'
 services:
   prometheus:
     build: .
-    # Eventhough exposing ports could be useful for discoverablilty
-    # Not exposing will make it easier to have two scrapers running
-    # ports:
-    #  - 9090:9090
+    ports:
+     - 9090:9090
     environment:
-     - PROM_REMOTE_WRITE_HOST
-     - PROM_REMOTE_WRITE_USERNAME
-     - PROM_REMOTE_WRITE_PASSWORD
      - PROM_ENDPOINT_TO_SCRAPE
      - PROM_JOB_NAME
+     - PROM_HTTP_PASSWORD
     extra_hosts:
     - "host.docker.internal:host-gateway"

--- a/prometheus/entrypoint.sh
+++ b/prometheus/entrypoint.sh
@@ -5,4 +5,4 @@ set -ex
 /bin/confd -onetime -backend env
 
 # Run Prometheus.
-/bin/prometheus --config.file=/etc/prometheus/confd-prometheus.yml --log.level=debug
+/bin/prometheus --web.config.file=/etc/prometheus/confd-prometheus-web.yml --config.file=/etc/prometheus/confd-prometheus.yml --log.level=debug

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -71,11 +71,13 @@ export function runServer(
     res.setHeader("Content-Type", register.contentType);
     res.send(await register.metrics());
   });
-
+  const port = process.env.METRIC_SERVER_PORT
+    ? parseInt(process.env.METRIC_SERVER_PORT)
+    : 8084;
   // Run Express HTTP server.
-  app.listen(8084, () => {
+  app.listen(port, () => {
     console.log(
-      "Prometheus HTTP server is running on http://localhost:8084, metrics are exposed on http://localhost:8084/metrics"
+      `Prometheus HTTP server is running on http://localhost:${port}, metrics are exposed on http://localhost:${port}/metrics`
     );
   });
 }


### PR DESCRIPTION
When using a custom grafana deployment we need manage the prometheus server ourselves. 

This PR
- Exposes prometheus on port 9090
- Adds http authetication