### PR TITLE
Add totalLiquidations metric

### DIFF
--- a/src/keeper.ts
+++ b/src/keeper.ts
@@ -197,7 +197,10 @@ class Keeper {
     await this.runKeepers();
   }
 
-  async updateIndex(events: ethers.Event[]) {
+  async updateIndex(
+    events: ethers.Event[],
+    deps = { totalLiquidationsMetric: metrics.totalLiquidations }
+  ) {
     events.forEach(({ event, args }) => {
       if (event === EventsOfInterest.PositionModified && args) {
         const { id, account, size, margin, lastPrice } = args;
@@ -245,6 +248,10 @@ class Keeper {
           { component: "Indexer" }
         );
 
+        deps.totalLiquidationsMetric.inc({
+          market: this.baseAsset,
+          network: this.network,
+        });
         delete this.positions[account];
         return;
       }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -32,12 +32,17 @@ export const futuresOpenPositions = new client.Gauge({
 });
 export const futuresLiquidations = new client.Gauge({
   name: "futures_liquidations",
-  help: "Number of liquidations",
+  help: "Number of liquidations made by this keeper",
   labelNames: ["market", "network"],
 });
 export const keeperErrors = new client.Gauge({
   name: "keeper_errors",
   help: "Number of errors in running keeper tasks",
+  labelNames: ["market", "network"],
+});
+export const totalLiquidations = new client.Gauge({
+  name: "total_liquidations",
+  help: "Total number of liquidations",
   labelNames: ["market", "network"],
 });
 


### PR DESCRIPTION
Adds a metric to track all liquidations, as to compared to the current metric that only tracks liquidations made by this keeper