### PR TITLE
improve liquidation speed and ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"build": "tsc && cp .env build/ && cp .env.staging build/",
 		"lint": "eslint \"src/**/*.js\" \"tools/**/*.js\" *.js",
 		"lint:fix": "eslint --fix \"src/**/*.js\" \"tools/**/*.js\" *.js",
-		"postinstall": "patch-package"
+		"postinstall": "patch-package",
+		"test":"jest"
 	},
 	"engines": {
 		"node": ">=10.0.0"

--- a/src/keeper.ts
+++ b/src/keeper.ts
@@ -237,6 +237,7 @@ class Keeper {
           account,
           size: wei(size).toNumber(),
           leverage: wei(size)
+            .abs()
             .mul(lastPrice)
             .div(margin)
             .toNumber(),

--- a/src/keeper.ts
+++ b/src/keeper.ts
@@ -183,18 +183,21 @@ class Keeper {
   }
 
   async processNewBlock(blockNumber: string) {
-    this.blockTip = blockNumber;
-    const events = await this.getEvents(blockNumber, blockNumber);
-
     this.logger.log("debug", `\nProcessing block: ${blockNumber}`, {
       component: "Indexer",
     });
+    this.blockTip = blockNumber;
 
+    // first try to liquidate any positions that can be liquidated now
+    await this.runKeepers();
+
+    // now process new events to update index, since it's impossible for a position that 
+    // was just updated to be liquidatable at the same block
+    const events = await this.getEvents(blockNumber, blockNumber);
     this.logger.log("debug", `${events.length} events to process`, {
       component: "Indexer",
     });
-    await this.updateIndex(events);
-    await this.runKeepers();
+    await this.updateIndex(events);    
   }
 
   async updateIndex(


### PR DESCRIPTION
Two small improvements that can possibly have an effect on liquidation speed:
- on new block this runs liquidations first, and processes new events after that
- leverage is calculated with abs() so that shorts will not have negative leverage (which is important since position are checked in order of leverage)

A follow up is to use `liquidationPrice` view, but it would require more changes since it's not available from just the events, so awaiting it will slow down events processing.