### PR TITLE
Metrics fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"start": "pm2 start ecosystem.config.js",
 		"dev": "name=futures-keeper-kovan ts-node-dev --respawn --transpile-only src/index.ts run",
+		"dev-mainnet": "name=futures-keeper-mainnet ts-node-dev --respawn --transpile-only src/index.ts run",
 		"build": "tsc && cp .env build/ && cp .env.staging build/",
 		"lint": "eslint \"src/**/*.js\" \"tools/**/*.js\" *.js",
 		"lint:fix": "eslint --fix \"src/**/*.js\" \"tools/**/*.js\" *.js",

--- a/src/keeper.test.ts
+++ b/src/keeper.test.ts
@@ -179,7 +179,14 @@ describe("keeper", () => {
       [
         {
           event: "PositionModified",
-          args: { id: "1", account: "___ACCOUNT1__", size: BigNumber.from(0), tradeSize: BigNumber.from(0) },
+          args: {
+            id: "1",
+            account: "___ACCOUNT1__",
+            size: BigNumber.from(0),
+            margin: BigNumber.from(0),
+            tradeSize: BigNumber.from(0),
+            lastPrice: BigNumber.from(1),
+          },
         },
       ] as any,
       deps
@@ -223,8 +230,8 @@ describe("keeper", () => {
 
     // push some values
     keeper.blockTipTimestamp = 1;
-    keeper.pushTradeToVolumeQueue(size, price);
-    keeper.pushTradeToVolumeQueue(size.mul(BigNumber.from("-1")), price);
+    keeper.pushTradeToVolumeQueue(size, price, "");
+    keeper.pushTradeToVolumeQueue(size.mul(BigNumber.from("-1")), price, "");
 
     const expectedVolume = price.mul(size.add(size));
     const expectedVolumeUSD = parseFloat(
@@ -244,14 +251,14 @@ describe("keeper", () => {
 
     // push some old values
     keeper.blockTipTimestamp = 1;
-    keeper.pushTradeToVolumeQueue(size, price);
-    keeper.pushTradeToVolumeQueue(size, price);
+    keeper.pushTradeToVolumeQueue(size, price, "");
+    keeper.pushTradeToVolumeQueue(size, price, "");
 
     // push some newer values
     keeper.blockTipTimestamp = 10000000;
-    keeper.pushTradeToVolumeQueue(size, price);
-    keeper.pushTradeToVolumeQueue(size, price);
-    keeper.pushTradeToVolumeQueue(size, price);
+    keeper.pushTradeToVolumeQueue(size, price, "");
+    keeper.pushTradeToVolumeQueue(size, price, "");
+    keeper.pushTradeToVolumeQueue(size, price, "");
 
     const deps = {
       recentVolumeMetric: { set: jest.fn() },
@@ -279,7 +286,10 @@ describe("keeper", () => {
     const FundingRecomputedMock = jest
       .fn()
       .mockReturnValue("__FundingRecomputed_EVENT_FILTER__");
-    const event = { event: "FundingRecomputed", args: { timestamp: wei(100000) } };
+    const event = {
+      event: "FundingRecomputed",
+      args: { timestamp: wei(100000) },
+    };
     const arg = {
       baseAsset: "sUSD",
       futuresMarket: {

--- a/src/keeper.test.ts
+++ b/src/keeper.test.ts
@@ -135,6 +135,7 @@ describe("keeper", () => {
             id: "1",
             account: "___ACCOUNT1__",
             size: wei(1).toBN(),
+            tradeSize: wei(1).toBN(),
             lastPrice: price,
             margin: wei(20000).toBN(),
           },
@@ -178,7 +179,7 @@ describe("keeper", () => {
       [
         {
           event: "PositionModified",
-          args: { id: "1", account: "___ACCOUNT1__", size: BigNumber.from(0) },
+          args: { id: "1", account: "___ACCOUNT1__", size: BigNumber.from(0), tradeSize: BigNumber.from(0) },
         },
       ] as any,
       deps

--- a/src/keeper.ts
+++ b/src/keeper.ts
@@ -237,6 +237,12 @@ class Keeper {
     // was just updated to be liquidatable at the same block
     const events = await this.getEvents(blockNumber, blockNumber);
     this.blockTip = blockNumber;
+    if (!events.length) {
+      // set block timestamp here in case there were no events to update the timestamp from
+      this.blockTipTimestamp = (
+        await this.provider.getBlock(blockNumber)
+      ).timestamp;
+    }
     this.logger.log(
       "info",
       `Processing new block: ${blockNumber}, ${events.length} events to process`,
@@ -259,7 +265,8 @@ class Keeper {
     events.forEach(({ event, args, blockNumber }) => {
       if (event === EventsOfInterest.FundingRecomputed && args) {
         // just a sneaky way to get timestamps without making awaiting getBlock() calls
-        // keeping track of time is needed for the volume metrics
+        // keeping track of time is needed for the volume metrics during the initial
+        // sync so that we don't have to await getting block timestamp for each new block
         this.blockTipTimestamp = args.timestamp.toNumber();
         this.logger.log(
           "debug",


### PR DESCRIPTION
Fix OI, skew, volume, and position keeping:
- fix event sorting so that indexing results in correct end state (sort by block number, tx index, log index)
- fix using size instead of tradeSize for volume tracking :man_facepalming: 
- fix deleting positions based on 0 size (since a 0 size even, still can have non zero tradeSize due to closing)

Also improved logging usefulness and reduced spam,

Issues discovered:
- Inaccuracy in dune dashboards due to not accounting for liquidations correctly.
- Adding warning for future possible limits to events query from RPC (might run into limits at 10000), at which point we'll need to paginate / batch.