### PR TITLE
CI deployments

### DIFF
--- a/.github/workflows/deploy-keeper.yml
+++ b/.github/workflows/deploy-keeper.yml
@@ -24,8 +24,9 @@ jobs:
           touch .env
           echo ETH_HDWALLET_MNEMONIC=${{ secrets.ETH_HDWALLET_MNEMONIC }} >> .env
           echo PROVIDER_URL=https://optimism-mainnet.infura.io/v3/${{ secrets.INFURA_PROJECT_ID }} >> .env
-          echo METRIC_SERVER_PORT=8085
-          echo NETWORK=mainnet-ovm
+          echo METRIC_SERVER_PORT=8085 >> .env
+          echo NETWORK=mainnet-ovm >> .env
+        if: github.ref == 'refs/heads/master'
         if: github.ref == 'refs/heads/master'
 
       - name: Create .env.staging file
@@ -33,8 +34,8 @@ jobs:
           touch .env.staging
           echo ETH_HDWALLET_MNEMONIC=${{ secrets.ETH_HDWALLET_MNEMONIC }} >> .env
           echo PROVIDER_URL=https://optimism-kovan.infura.io/v3/${{ secrets.INFURA_PROJECT_ID }} >> .env
-          echo METRIC_SERVER_PORT=8084
-          echo NETWORK=kovan-ovm
+          echo METRIC_SERVER_PORT=8084 >> .env
+          echo NETWORK=kovan-ovm >> .env
         if: github.ref == 'refs/heads/develop'
 
       - name: Deploy

--- a/.github/workflows/deploy-keeper.yml
+++ b/.github/workflows/deploy-keeper.yml
@@ -27,6 +27,19 @@ jobs:
           echo METRIC_SERVER_PORT=8085 >> .env
           echo NETWORK=mainnet-ovm >> .env
         if: github.ref == 'refs/heads/master'
+      
+      - name: Create prometheus .env file
+        run: |
+          cd prometheus
+          touch .env
+          echo PROM_ENDPOINT_TO_SCRAPE=host.docker.internal:8085 >> .env
+          echo PROM_JOB_NAME=keeper-mainnet-ovm >> .env
+          echo PROM_PORT=9091 >> .env
+          echo PROM_HTTP_PASSWORD=${{ secrets.PROM_HTTP_PASSWORD }} >> .env
+          echo PROM_STAGING_PORT=9090 >> .env
+          echo PROM_STAGING_JOB_NAME=keeper-kovan-ovm >> .env
+          echo PROM_STAGING_ENDPOINT_TO_SCRAPE=host.docker.internal:8084 >> .env
+
         if: github.ref == 'refs/heads/master'
 
       - name: Create .env.staging file

--- a/.github/workflows/deploy-keeper.yml
+++ b/.github/workflows/deploy-keeper.yml
@@ -6,6 +6,36 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+
+      - name: Install SSH key
+        uses: synthetixio/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+      
+      - name: Checkout
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # pin@v2
+
       - name: Targeting branch
         run: echo "$GITHUB_REF_NAME"
-        if: "$GITHUB_REF_NAME==develop"
+     
+      - name: Create .env file
+        run: |
+          touch .env
+          echo ETH_HDWALLET_MNEMONIC=${{ secrets.ETH_HDWALLET_MNEMONIC }} >> .env
+          echo PROVIDER_URL=https://optimism-mainnet.infura.io/v3/${{ secrets.INFURA_PROJECT_ID }} >> .env
+          echo METRIC_SERVER_PORT=8085
+          echo NETWORK=mainnet-ovm
+        if: github.ref == 'refs/heads/master'
+
+      - name: Create .env.staging file
+        run: |
+          touch .env.staging
+          echo ETH_HDWALLET_MNEMONIC=${{ secrets.ETH_HDWALLET_MNEMONIC }} >> .env
+          echo PROVIDER_URL=https://optimism-kovan.infura.io/v3/${{ secrets.INFURA_PROJECT_ID }} >> .env
+          echo METRIC_SERVER_PORT=8084
+          echo NETWORK=kovan-ovm
+        if: github.ref == 'refs/heads/develop'
+
+      - name: Deploy
+        run: sh ./deploy.sh "${{ secrets.SERVER_USER }}@${{ secrets.SERVER_IP }}" "${{secrets.SERVER_PATH}}" "$GITHUB_REF_NAME"

--- a/.github/workflows/deploy-keeper.yml
+++ b/.github/workflows/deploy-keeper.yml
@@ -1,0 +1,11 @@
+name: "Deploy"
+on:
+  push:
+    branches: [master, develop]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Targeting branch
+        run: echo "$GITHUB_REF_NAME"
+        if: "$GITHUB_REF_NAME==develop"

--- a/README.md
+++ b/README.md
@@ -92,16 +92,12 @@ Prometheus is a pull-based instrumentation system. We must run a separate Promet
 
 ## Deployment notes
 
-A simple deployment script is provided: `deploy.sh`. It probably make sense for you to customize it for your own needs, but it serves as a starting point/ example.
+We use github actions for continuos deployments. See /.github/workflows/deploy-keeper.yml
 
-We expect that you have node v16, docker and docker-compose installed on the server. If you do,
-Make sure the `.env` and `prometheus/.env` is configured and run:
-`sh deploy.sh ~/.ssh/my-ssh-key user@ip /server/path/`
+- Merge/Push to branch `develop` will trigger a staging release and start the keeper on `ovm-kovan`
+- Merge/Push to branch `master` will trigger a production release and start the keeper on `ovm-mainnet`
 
-This will upload the code, install npm dependencies, compile typescript, start the keeper **with default arguments** and start the metric server.
-
-You can stop the keeper by running:
-`sh ./stop-keeper-on-server.sh ~/.ssh/my-ssh-key user@ip`
+To set this up as a fork we need to create github secrets for all required environment variables
 
 ## Future improvements
 

--- a/README.md
+++ b/README.md
@@ -102,5 +102,3 @@ To set this up as a fork we need to create github secrets for all required envir
 ## Future improvements
 
 - Currently we only have unit tests. Manual integrations tests can be run with the Futures interact CLI, but ideally we should add some proper integration tests.
-
-- The current flow is very inefficient (checks all positions every block), which means that it's possible that liquidations won't keep up due to node chatter bottleneck. The implementation should maintain a view of position liquidation prices (by following events / subgraph) and only check liquidation status for the positions most at risk (liquidation price closest to current price).

--- a/deploy.sh
+++ b/deploy.sh
@@ -37,8 +37,16 @@ ssh "$USER_AT_IP" mkdir -p "$FULL_SERVER_PATH"
 echo "Uploading files"
 rsync --exclude 'node_modules' --exclude 'build' --exclude 'coverage' --exclude 'cache' -e "ssh" -Pav "$PWD/" "$USER_AT_IP":"$FULL_SERVER_PATH"
 
-echo "Installing deps, transpiling typescript and starting keeper"
-ssh "$USER_AT_IP" "cd $FOLDER_NAME;npm i;npm run build;npm run start"
+echo "Installing deps, transpiling typescript"
+ssh "$USER_AT_IP" "cd $FOLDER_NAME;npm i;npm run build"
+
+if [ "$ENVIRONMENT" = "production" ]; then
+    echo "Starting mainnet keeper"
+    ssh "$USER_AT_IP" "cd $FOLDER_NAME;npm run start-mainnet"
+else
+    echo "Starting kovan keeper"
+    ssh "$USER_AT_IP" "cd $FOLDER_NAME;npm run start-kovan"
+fi
 
 if [ "$ENVIRONMENT" = "production" ]; then
     echo "Starting prometheus scraper"

--- a/deploy.sh
+++ b/deploy.sh
@@ -52,7 +52,9 @@ if [ "$ENVIRONMENT" = "production" ]; then
     echo "Starting prometheus scraper"
     ssh "$USER_AT_IP" "cd $FOLDER_NAME/prometheus; docker-compose --env-file ./.env up -d"
 else
-    echo "ENVIRONMENT is $ENVIRONMENT, skipping prometheus"
+    echo "ENVIRONMENT is $ENVIRONMENT, skipping prometheus and removing prometheus code"
+    ssh "$USER_AT_IP" "cd $FOLDER_NAME; rm -r prometheus"
+    
 fi
 
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,46 +2,49 @@
 set -ex
 
 
-if [ -z $1 ] ; then
-    echo "PATH_TO_PRIVATE_KEY required!" && exit 1;
-fi
 
-if [ -z $2 ] ; then
+
+if [ -z $1 ] ; then
     echo "USER:IP parameter required!" && exit 1;
 fi
-if [ -z $3 ] ; then
-    echo "SERVER_PATH parameter required!" && exit 1;
+if [ -z $2 ] ; then
+    echo "SERVER_HOME_PATH parameter required!" && exit 1;
 fi
 
-PATH_TO_PRIVATE_KEY=$1
-USER_AT_IP=$2
-SERVER_PATH=$3
-CURRENT=`pwd`
-LOCAL_FOLDER_NAME=`basename "$CURRENT"`
 
 
-confirm() {
-    # call with a prompt string or use a default
-    read -r -p "${1:-Are .env files updated? [y/N]} " response
-    case "$response" in
-        [yY][eE][sS]|[yY])
-            true
-        ;;
-        *)
-            false
-        ;;
-    esac
+USER_AT_IP=$1
+SERVER_HOME_PATH=$2
+BRANCH=${3:-"develop"}
+
+if [ "$BRANCH" = "master" ]; then
+    ENVIRONMENT="production"
+    FOLDER_NAME="futures-keepers"
+else
+    FOLDER_NAME="futures-keepers-staging"
+    ENVIRONMENT="staging"
+fi
+
+join_path() {
+    echo "${1:+$1/}$2" | sed 's#//#/#g'
 }
 
+FULL_SERVER_PATH=$(join_path $SERVER_HOME_PATH $FOLDER_NAME)
 
-confirm || exit 0
+echo "Creating folder if not exists"
+ssh "$USER_AT_IP" mkdir -p "$FULL_SERVER_PATH"
 
-ssh -i "$PATH_TO_PRIVATE_KEY" "$USER_AT_IP" mkdir -p "$SERVER_PATH"
 echo "Uploading files"
-rsync --exclude 'node_modules' --exclude 'build' --exclude 'coverage' --exclude 'cache' -e "ssh -i $PATH_TO_PRIVATE_KEY" -Pav "$PWD" "$USER_AT_IP":"$SERVER_PATH"
+rsync --exclude 'node_modules' --exclude 'build' --exclude 'coverage' --exclude 'cache' -e "ssh" -Pav "$PWD/" "$USER_AT_IP":"$FULL_SERVER_PATH"
 
 echo "Installing deps, transpiling typescript and starting keeper"
-ssh -i "$PATH_TO_PRIVATE_KEY" "$USER_AT_IP" "cd $LOCAL_FOLDER_NAME;npm i;npm run build;npm run start"
-echo "Starting prometheus scraper"
-ssh -i "$PATH_TO_PRIVATE_KEY" "$USER_AT_IP" "cd $LOCAL_FOLDER_NAME/prometheus; docker-compose --env-file ./.env up -d"
+ssh "$USER_AT_IP" "cd $FOLDER_NAME;npm i;npm run build;npm run start"
+
+if [ "$ENVIRONMENT" = "production" ]; then
+    echo "Starting prometheus scraper"
+    ssh "$USER_AT_IP" "cd $FOLDER_NAME/prometheus; docker-compose --env-file ./.env up -d"
+else
+    echo "ENVIRONMENT is $ENVIRONMENT, skipping prometheus"
+fi
+
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
 	"license": "MIT",
 	"scripts": {
 		"start": "pm2 start ecosystem.config.js",
+		"start-mainnet": "pm2 start ecosystem.config.js --only futures-keeper-mainnet",
+		"start-kovan": "pm2 start ecosystem.config.js --only futures-keeper-kovan",
 		"dev": "name=futures-keeper-kovan ts-node-dev --respawn --transpile-only src/index.ts run",
 		"dev-mainnet": "name=futures-keeper-mainnet ts-node-dev --respawn --transpile-only src/index.ts run",
 		"build": "tsc && cp .env build/ && cp .env.staging build/",

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -37,6 +37,11 @@ The setup can be run with Docker Compose and configured using environment variab
     docker-compose --env-file ./.env up
     ```
 
+## Deployment notes
+
+When code is merged to `master` the github action `deploy-keeper.yml` will run `docker-compose --env-file ./.env up -d`.
+This will start an instance for both kovan-ovm and mainnet-ovm. Currently there's no separate staging deployment
+
 ## Props.
 
 Inspiration taken from https://github.com/zakkg3/Prometheus-confd


### PR DESCRIPTION
This adds PR adds continuous deployments.

Merge/push to `develop` branch will deploy code to `futures-keepers-staging` and starting the keeper on `kovan-ovm`.
Merge/push to `master` branch will deploy code to `futures-keepers` and starting the keeper on `mainnet-ovm`.

We're only running one docker container for `prometheus` (production), the prometheus folder will not exists in `futures-keepers-staging`. It's not perfect but we should rarely have to do any changes for prometheus.
