### PR TITLE
Cloudwatch is getting a bit slow, use a date for logStreamName

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,6 +1,8 @@
 import winston, { format, transports } from "winston";
 import WinstonCloudWatch from "winston-cloudwatch";
 
+// This should create a new log stream every time the app starts
+const logStreamName = new Date().toISOString();
 export function createLogger({ componentName }: { componentName: string }) {
   const logger = winston.createLogger({
     level: "info",
@@ -34,7 +36,7 @@ export function createLogger({ componentName }: { componentName: string }) {
     logger.add(
       new WinstonCloudWatch({
         logGroupName,
-        logStreamName: logGroupName,
+        logStreamName: logStreamName,
         messageFormatter(x) {
           //passed in meta data is not available here :(
           return `${x.level} ${componentName} ${x.message}`;


### PR DESCRIPTION
This should create a new logStrem every time we deploy/ or the app restarts