### PR TITLE
Update dependency workflow

### DIFF
--- a/.github/workflows/update-dependency
+++ b/.github/workflows/update-dependency
@@ -1,0 +1,56 @@
+name: Update dependency
+
+on:
+  workflow_dispatch:
+    inputs:
+      monorepo_version:
+        description: 'New Monorepo Version (ex. 2.50.0-alpha) (leave empty to "patch")'
+        required: false
+
+jobs:
+  update_version:
+    name: Update contracts-interface version
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/synthetixio/docker-node/alpine:14.17
+      credentials:
+        username: synthetixio
+        password: ${{ secrets.GH_PACKAGES_READ_ONLY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v2
+
+      - name: Set npm cache directory
+        run: npm config set cache .npm-cache --global
+        continue-on-error: true
+
+      - name: Cache node modules
+        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09 # pin@v2
+        with:
+          path: |
+            .npm-cache
+            node_modules
+          key: ${{ runner.os }}-alpine-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-alpine-node-
+        continue-on-error: true
+
+      # fix: permission issues on ghactions+docker+npm@7
+      - name: Chown workspace
+        run: chown -R $(whoami) .
+
+      - name: Install dependencies
+        run: npm install --prefer-offline --no-audit
+
+      - name: Update all @synthetixio/* dependency
+        run: "sed -i 's/\"@synthetixio\\/\\(.*\\)\": \".*\"/\"@synthetixio\\/\\1\": \"${{ github.event.inputs.monorepo_version }}\"/' package.json"
+
+      - run: npm install
+
+      - name: Commit changes
+        run: |
+          git config --global user.email "team@synthetix.io" && git config --global user.name "Synthetix Team"
+          git commit -am 'contracts-interface@${{ github.event.inputs.version }}'
+          git push origin develop

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
 				"prettier": "1.19.1",
 				"pretty-error": "3.0.4",
 				"prom-client": "14.0.0",
-				"synthetix": "2.67.0-alpha",
 				"typescript": "4.5.2",
 				"winston": "3.3.3",
 				"winston-cloudwatch": "4.0.1"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
 		"prettier": "1.19.1",
 		"pretty-error": "3.0.4",
 		"prom-client": "14.0.0",
-		"synthetix": "2.67.0-alpha",
 		"typescript": "4.5.2",
 		"winston": "3.3.3",
 		"winston-cloudwatch": "4.0.1"


### PR DESCRIPTION
- Remove synthetix package.  It's unused we grab packages from js-monorepo
- Add update dependency workflow that js-monorepo can trigger when there's a new release

js-monorepo PR that will trigger this workflow: 
https://github.com/Synthetixio/js-monorepo/pull/186